### PR TITLE
Assignee as trigger

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,13 @@ inputs:
   label-operator:
     required: false
     description: The behavior of the labels filter, AND to match all labels, OR to match any label (default is OR)
+  assignee:
+    required: false
+    description: A comma-separated list of assignees to use as a filter for issue to be added
+  assignee-operator:
+    required: false
+    description: The behavior of the assignee filter, AND to match all assignees, OR to match any assignee (default is OR)
+
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.7.0",
         "@actions/github": "^5.0.0"
       },
       "devDependencies": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==",
       "dependencies": {
         "@actions/http-client": "^1.0.11"
       }
@@ -6463,9 +6463,9 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==",
       "requires": {
         "@actions/http-client": "^1.0.11"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "author": "GitHub and contributors",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.7.0",
     "@actions/github": "^5.0.0"
   },
   "engines": {

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -31,12 +31,7 @@ interface ProjectAddItemResponse {
 export async function addToProject(): Promise<void> {
   const projectUrl = core.getInput('project-url', {required: true})
   const ghToken = core.getInput('github-token', {required: true})
-  const labeled =
-    core
-      .getInput('labeled')
-      .split(',')
-      .map(l => l.trim())
-      .filter(l => l.length > 0) ?? []
+  const labeled = getLabelOrAssignee('labeled')
   const labelOperator = core.getInput('label-operator').trim().toLocaleLowerCase()
 
   const octokit = github.getOctokit(ghToken)
@@ -123,4 +118,15 @@ export function mustGetOwnerTypeQuery(ownerType?: string): 'organization' | 'use
   }
 
   return ownerTypeQuery
+}
+
+// Get and clean input from workflow
+export function getLabelOrAssignee(name: string): string[] {
+  const input = 
+    core
+      .getInput(name)
+      .split(',')
+      .map(l => l.trim())
+      .filter(l => l.length > 0) ?? []
+  return input
 }

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -43,12 +43,12 @@ export async function addToProject(): Promise<void> {
   const labelFilterValid = filterForLabelOrAssignee(labeled, labelOperator, issue, issueLabels)
   const assigneeFilterValid = filterForLabelOrAssignee(assignee, assigneeOperator, issue, issueAssignees)
   
-  core.info(`Labels: ${labeled.join(', ')}`)
-  core.info(`Assignees: ${assignee.join(', ')}`)
-  core.info(`Issue labels: ${issueLabels.join(', ')}`)
-  core.info(`Issue assignees: ${issueAssignees.join(', ')}`)
-  core.info(`Label filter valid: ${labelFilterValid}`)
-  core.info(`Assignee filter valid: ${assigneeFilterValid}`)
+  core.debug(`Labels: ${labeled.join(', ')}`)
+  core.debug(`Assignees: ${assignee.join(', ')}`)
+  core.debug(`Issue labels: ${issueLabels.join(', ')}`)
+  core.debug(`Issue assignees: ${issueAssignees.join(', ')}`)
+  core.debug(`Label filter valid: ${labelFilterValid}`)
+  core.debug(`Assignee filter valid: ${assigneeFilterValid}`)
   
   if (!labelFilterValid || !assigneeFilterValid) {
     return

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -1,5 +1,8 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
+import { Interface } from 'readline'
+import { DefaultDeserializer } from 'v8'
+import { IssueOrPRComponent, WorkflowComponent } from './component'
 
 // TODO: Ensure this (and the Octokit client) works for non-github.com URLs, as well.
 // https://github.com/orgs|users/<ownerName>/projects/<projectNumber>
@@ -31,18 +34,26 @@ interface ProjectAddItemResponse {
 export async function addToProject(): Promise<void> {
   const projectUrl = core.getInput('project-url', {required: true})
   const ghToken = core.getInput('github-token', {required: true})
-  const labeled = getWorkflowInput('labeled'), assignee = getWorkflowInput('assignee')
-  const labelOperator = core.getInput('label-operator').trim().toLocaleLowerCase(), assigneeOperator = core.getInput('assignee-operator').trim().toLocaleLowerCase()
 
   const octokit = github.getOctokit(ghToken)
   const urlMatch = projectUrl.match(urlParse)
   const issue = github.context.payload.issue ?? github.context.payload.pull_request
-  const issueLabels: string[] = (issue?.labels ?? []).map((l: {name: string}) => l.name), issueAssignees: string[] = (issue?.assignees ?? []).map((a: {login: string}) => a.login)
 
-  // Only proceed if filters are valid.
-  filterForWorkflowInput(labeled, labelOperator, issue, issueLabels)
-  filterForWorkflowInput(assignee, assigneeOperator, issue, issueAssignees)
+  // Set up workflow component objects.
+  const workflowAssignee = new WorkflowComponent('assignee')
+  const workflowLabels = new WorkflowComponent('labeled')
+  workflowAssignee.operator = core.getInput('assignee-operator').trim().toLocaleLowerCase()
+  workflowLabels.operator = core.getInput('label-operator').trim().toLocaleLowerCase()
 
+  // Set up issue/PR component objects.
+  const assignee = new IssueOrPRComponent('assignee')
+  const labels = new IssueOrPRComponent('labels')
+  assignee.values = (issue?.assignees ?? []).map((a: {login: string}) => a.login)
+  labels.values = (issue?.labels ?? []).map((l: {name: string}) => l.name)
+
+  // Only proceed if the workflow assignee and labels match the issue/PR assignee and labels.
+  if(!workflowAssignee.matches(assignee) || !workflowLabels.matches(labels)) { return }
+  
   core.debug(`Project URL: ${projectUrl}`)
 
   if (!urlMatch) {
@@ -109,30 +120,4 @@ export function mustGetOwnerTypeQuery(ownerType?: string): 'organization' | 'use
   }
 
   return ownerTypeQuery
-}
-
-// Get and clean input from workflow. This input is expected to be either a label or an assignee
-export function getWorkflowInput(name: string): string[] {
-  const input = 
-    core
-      .getInput(name)
-      .split(',')
-      .map(l => l.trim())
-      .filter(l => l.length > 0) ?? []
-  return input
-}
-
-// Ensure the issue matches our `labeled` or `assignee` filter based on the matching operator.
-export function filterForWorkflowInput(input: string[], operator: string, issue: any, issueInput: string[]) {
-  if (operator === 'and') {
-    if (!input.every(l => issueInput.includes(l))) {
-      core.info(`Skipping issue ${issue?.number} because it doesn't match all the ${Object.keys({input})[0]}s: ${input.join(', ')}`)
-      return
-    }
-  } else {
-    if (input.length > 0 && !issueInput.some(l => input.includes(l))) {
-      core.info(`Skipping issue ${issue?.number} because it does not have one of the ${Object.keys({input})[0]}s: ${input.join(', ')}`)
-      return
-    }
-  }
 }

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -134,7 +134,7 @@ export function getLabelOrAssignee(name: string): string[] {
 }
 
 // Ensure the issue matches our `labeled` or `assignee` filter based on the matching operator.
-export function filterForLabelOrAssignee(input: string[], operator: string, issue: any, issueInput: string[]) {
+export function filterForLabelOrAssignee(input: string[], operator: string, issue: any, issueInput: string[]): boolean {
   if (operator === 'and') {
     if (!input.every(l => issueInput.includes(l))) {
       core.info(`Skipping issue ${issue?.number} because it doesn't match all the ${Object.keys({input})[0]}s: ${input.join(', ')}`)
@@ -146,4 +146,6 @@ export function filterForLabelOrAssignee(input: string[], operator: string, issu
       return false
     }
   }
+
+  return true
 }

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -126,7 +126,7 @@ export function getLabelOrAssignee(name: string): string[] {
 }
 
 // Ensure the issue matches our `labeled` or `assignee` filter based on the matching operator.
-export function filterForLabelOrAssignee(input: string[], operator: string, issue: any, issueInput: string[]): boolean {
+export function filterForLabelOrAssignee(input: string[], operator: string, issue: any, issueInput: string[]) {
   if (operator === 'and') {
     if (!input.every(l => issueInput.includes(l))) {
       core.info(`Skipping issue ${issue?.number} because it doesn't match all the ${Object.keys({input})[0]}s: ${input.join(', ')}`)

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -42,6 +42,14 @@ export async function addToProject(): Promise<void> {
   // Only proceed if filters are valid.
   const labelFilterValid = filterForLabelOrAssignee(labeled, labelOperator, issue, issueLabels)
   const assigneeFilterValid = filterForLabelOrAssignee(assignee, assigneeOperator, issue, issueAssignees)
+  
+  console.log(`Labels: ${labeled.join(', ')}`)
+  console.log(`Assignees: ${assignee.join(', ')}`)
+  console.log(`Issue labels: ${issueLabels.join(', ')}`)
+  console.log(`Issue assignees: ${issueAssignees.join(', ')}`)
+  console.log(`Label filter valid: ${labelFilterValid}`)
+  console.log(`Assignee filter valid: ${assigneeFilterValid}`)
+  
   if (!labelFilterValid || !assigneeFilterValid) {
     return
   }

--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -43,12 +43,12 @@ export async function addToProject(): Promise<void> {
   const labelFilterValid = filterForLabelOrAssignee(labeled, labelOperator, issue, issueLabels)
   const assigneeFilterValid = filterForLabelOrAssignee(assignee, assigneeOperator, issue, issueAssignees)
   
-  console.log(`Labels: ${labeled.join(', ')}`)
-  console.log(`Assignees: ${assignee.join(', ')}`)
-  console.log(`Issue labels: ${issueLabels.join(', ')}`)
-  console.log(`Issue assignees: ${issueAssignees.join(', ')}`)
-  console.log(`Label filter valid: ${labelFilterValid}`)
-  console.log(`Assignee filter valid: ${assigneeFilterValid}`)
+  core.info(`Labels: ${labeled.join(', ')}`)
+  core.info(`Assignees: ${assignee.join(', ')}`)
+  core.info(`Issue labels: ${issueLabels.join(', ')}`)
+  core.info(`Issue assignees: ${issueAssignees.join(', ')}`)
+  core.info(`Label filter valid: ${labelFilterValid}`)
+  core.info(`Assignee filter valid: ${assigneeFilterValid}`)
   
   if (!labelFilterValid || !assigneeFilterValid) {
     return

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,0 +1,59 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+
+// Define a class for an a general component.
+class Component {
+  name: string;
+  values: string[] = [];
+  constructor(name: string) {
+    this.name = name;
+  }
+  
+}
+
+// Define a class for a Issue or Pull Request component. This could be an assignee, label, etc.
+export class IssueOrPRComponent extends Component {
+  metadata = github.context.payload.issue ?? github.context.payload.pull_request;
+  constructor(name: string) {
+    super(name);
+  }
+  
+}
+
+// Define a class for a workflow components. This could be an assignee, label, etc.
+export class WorkflowComponent extends Component {
+    operator: string | undefined;
+    constructor(name: string) {
+      super(name);
+      this.values = this.getValues(name);
+    }
+
+    // Get the workflow input values.
+    getValues(name: string) {
+      return core
+        .getInput(name)
+        .split(',')
+        .map(n => n.trim())
+        .filter(n => n.length > 0) ?? []
+    }
+
+    // Check workflow input against issue/PR input.
+    // If the workflow input is not set, then it's a match.
+    matches(issueComponent: IssueOrPRComponent): boolean {
+      if (this.operator === 'and') {
+        if(!this.values.every(value => issueComponent.values.includes(value))) {
+          core.info(`Skipping issue ${issueComponent.metadata?.number} because it doesn't match all the fields from "${this.name}": ${this.values.join(', ')}`);
+          return false
+        }
+      } else {
+        if (this.values.length > 0 && !issueComponent.values.some(value => this.values.includes(value))) {
+          core.info(`Skipping issue ${issueComponent.metadata?.number} because it doesn't match one of the fields from "${this.name}": ${this.values.join(', ')}`);
+        return false
+        } 
+    }
+
+    return true
+  }
+
+
+}


### PR DESCRIPTION
## What's new?

Added the ability to use the issue or PR assignee as another workflow variable for this Action. The action now has the following functionalities:

### Label functionality

Using a label to filter which issue/PR is sent to the project of choice should work as it as before.

### Assignee functionality <sup>(new)</sup> 

You can now use an assignee (or multiple assignees) as a filter to choose which issue/PR will be sent to your project of choice.

This would be done using the `assignee` and `assignee-operator` inputs in your workflow as such:

````yaml
- uses: Eldrick19/add-to-project@main
        with:
          project-url: https://github.com/users/Eldrick19/projects/1
          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
          assignee: monalisa, octocat
          assignee-operator: AND
````

### Mix functionality <sup>(new)</sup> 

You can use both the `assignee` and `labeled` inputs together in your workflow. E.g.:

````yaml
- uses: Eldrick19/add-to-project@main
        with:
          project-url: https://github.com/users/Eldrick19/projects/1
          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
          labeled: bug, test
          assignee: monalisa, octocat
          assignee-operator: AND
````

In the example above, an issue or PR will be added to a project only if BOTH the following conditions are met:
- It has label `bug` or `test`, AND
- It has assignees `monalisa` and `octocat`

---

## What's new in the code?

1. Created classes for the **Workflow components** and **Issue/PR components**. A component can be a label/assignee/etc. 
    - Currently we're only using labels and assignees as components but this could maybe help if we wanted to add other components as filters?
2. Added tests for the new assignee component filter, as well as testing functionality when using both `assignee` and `label` as filters. These new tests are:
    - _adds matching pull-requests with a assignee filter without assignee-operator_ 
    - _adds matching issues when assignee and labels are set as filters_
    - _does not add un-matching issues when assignee and labels are set as filters_

---

## Discussion points

- I added this functionality because I wanted to trigger the workflow on myself being assigned, with the issue being added to my personal Projects _Beta_ board. 
- I also wanted to do it in a 'smart' way in case people wanted to add other filters in the future.
- Is this where the team even wants to take the action? I understand wanting to keep it simple and having the assignee functionality as a separate action as well.